### PR TITLE
Implement attendee management features and enhance event attendance t…

### DIFF
--- a/app/Http/Controllers/EventRegistrationController.php
+++ b/app/Http/Controllers/EventRegistrationController.php
@@ -246,7 +246,7 @@ class EventRegistrationController extends Controller
         Attendance::create([
             'attendee_id' => $attendee->id,
             'event_id' => $event->id,
-            'status' => 'present',
+            'status' => 'absent',
             'check_in_time' => null,
             'notes' => null,
         ]);
@@ -343,7 +343,6 @@ class EventRegistrationController extends Controller
                     // Dispatch job delete dengan delay 1 menit
                     dispatch(new DeleteQrJob($qrPath))
                         ->delay(now()->addMinute());
-
                 } catch (Exception $e) {
                     return response()->json([
                         'message' => 'Failed to send WhatsApp message',

--- a/app/Http/Controllers/api/ApiScanEventController.php
+++ b/app/Http/Controllers/api/ApiScanEventController.php
@@ -28,9 +28,7 @@ class ApiScanEventController extends Controller
             'qrcode_data' => 'required|string',
         ]);
 
-
-        
-          // Langsung return response dari service
+        // Langsung return response dari service
         return $this->attendanceService->scanAttendance($id, $request->qrcode_data, $request->user()->id);
     }
 
@@ -40,9 +38,7 @@ class ApiScanEventController extends Controller
             'qrcode_data' => 'required|string',
         ]);
 
-
-        
-          // Langsung return response dari service
+        // Langsung return response dari service
         return $this->attendanceService->scanIdentityCheck($id, $request->qrcode_data, $request->user()->id);
     }
 }

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -17,6 +17,7 @@ class EventResource extends JsonResource
         return [
             'id' => $this->id,
             'title' => $this->title,
+            'event_status' => $this->event_status,
             'description' => $this->description,
             'location' => $this->location,
             'category' => optional($this->eventCategory)->name,

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -50,6 +50,12 @@ class Event extends Model
             ->count();
     }
 
+    public function countAttendees()
+    {
+        return $this->attendance()
+            ->count();
+    }
+
     public function attendance()
     {
         return $this->hasMany(Attendance::class);

--- a/app/Models/QRCode.php
+++ b/app/Models/QRCode.php
@@ -17,7 +17,7 @@ class QRCode extends Model
         'event_id',
         'attendee_id',
         'qrcode_data', // kombinasi antara code yang dimiliki attendee dengan id events, contoh: event=10 code=520 maka 10520 atau 52010 (tetapi nanti untuk code akan di randomize)
-        'valid_until'
+        'valid_until'   
     ];
 
     public function event() {

--- a/app/Services/AttendanceService.php
+++ b/app/Services/AttendanceService.php
@@ -27,6 +27,35 @@ class AttendanceService
     // Get the event
     $event = Event::findOrFail($eventId);
 
+    // Check if event has started
+    $now = Carbon::now();
+    $eventStarted = $now->isAfter($event->start_date) || $now->isSameDay($event->start_date);
+    $eventEnded = $now->isAfter($event->end_date);
+
+    if (!$eventStarted) {
+      // Event hasn't started yet
+      return response()->json([
+        'success' => false,
+        'message' => 'Event has not started yet',
+      ], 400);
+    }
+
+    // Check if event is active but already ended
+    if ($event->status === 'active' && $eventEnded) {
+      return response()->json([
+        'success' => false,
+        'message' => 'The event status is active but it has already ended',
+      ], 400);
+    }
+
+    // Check if event is done/cancelled but still within date range
+    if (($event->status === 'done' || $event->status === 'cancelled') && !$eventEnded) {
+      return response()->json([
+        'success' => false,
+        'message' => 'The event is marked as ' . $event->status . ' but the event dates are still ongoing',
+      ], 400);
+    }
+
     /**
      * Searches for the specified QR code within the database.
      * This step is essential to verify the existence and validity of the QR code
@@ -37,6 +66,21 @@ class AttendanceService
       ->where('event_id', $eventId)
       ->first();
 
+    if (!$qrCode) {
+      // Log invalid scan attempt
+      QRCodeLog::create([
+        'qr_code_id' => null,
+        'attendee_id' => null,
+        'user_id' => $userId,
+        'status' => 'invalid',
+      ]);
+
+      return response()->json([
+        'success' => false,
+        'message' => 'Invalid QR code',
+      ], 400);
+    }
+
     /**
      * Verifies whether the attendance for the current event has already been recorded.
      * Prevents duplicate attendance entries for the same participant and event.
@@ -44,7 +88,7 @@ class AttendanceService
     // Check if attendance already recorded
     $existingAttendance = Attendance::where('attendee_id', $qrCode->attendee_id)
       ->where('event_id', $eventId)
-      ->where('status', 'present')
+      ->where('status', 'Present')
       ->first();
 
     if ($existingAttendance) {
@@ -57,7 +101,7 @@ class AttendanceService
         'qr_code_id' => $qrCode->id,
         'attendee_id' => $qrCode->attendee_id,
         'user_id' => $userId,
-        'status' => 'invalid',
+        'status' => 'Invalid',
       ]);
 
       return response()->json([
@@ -66,6 +110,8 @@ class AttendanceService
         'data' => [
           'attendee' => $qrCode->attendee,
           'attendance' => $existingAttendance,
+          'qr_code' => $qrCode,
+
         ],
       ], 200);
     }
@@ -152,6 +198,8 @@ class AttendanceService
         'status' => 'scanned',
       ]);
 
+      $isLate = Carbon::now()->greaterThan($event->start_date->copy()->addMinutes($event->start_date->diffInMinutes($event->end_date) * 0.95)) ? true : false;
+
       /**
        * Updates an existing attendance record or creates a new one if it does not exist.
        * This method ensures that the attendance information for an event is accurately
@@ -161,13 +209,16 @@ class AttendanceService
        * attendance status for the event.
        */
       // Update or create attendance record
+
+
       $attendance = Attendance::updateOrCreate(
         [
           'attendee_id' => $attendee->id,
           'event_id' => $eventId,
         ],
         [
-          'status' => 'present',
+          // event is considered 'Late' if scanned after 95% of event duration has passed
+          'status' => Carbon::now()->greaterThan($event->start_date->copy()->addMinutes($event->start_date->diffInMinutes($event->end_date) * 0.95)) ? 'Late' : 'Present',
           'check_in_time' => Carbon::now(),
         ]
       );
@@ -309,7 +360,102 @@ class AttendanceService
       'data' => [
         'attendee' => $attendee,
         'attendance' => $attendance,
+        'qr_code' => $qrCode,
       ],
     ], 200);
+  }
+
+  public function getEventAttendees($eventId)
+  {
+    $event = Event::findOrFail($eventId);
+    $attendees = $event->attendees()->with('attendance')->get();
+    return response()->json([
+      'success' => true,
+      'data' => [
+        'attendees' => $attendees,
+      ],
+    ], 200);
+  }
+
+  public function updateAttendees($eventId, $attendeesData, $userId)
+  {
+    try {
+      // Verify the event exists
+      $event = Event::findOrFail($eventId);
+
+      // Begin transaction
+      DB::beginTransaction();
+
+      $updatedCount = 0;
+      $notFoundCount = 0;
+
+      foreach ($attendeesData as $attendeeData) {
+        $attendeeId = $attendeeData['id'];
+        // Laravel best practice: konsistensi kapitalisasi status
+        $status = strtolower($attendeeData['status']) === 'present' ? 'Present' : 'Absent';
+
+        // Check if attendee belongs to this event
+        $attendee = $event->attendees()->where('id', $attendeeId)->first();
+
+        if (!$attendee) {
+          $notFoundCount++;
+          continue; // Skip this attendee
+        }
+
+        // Find or create attendance record
+        $attendance = Attendance::updateOrCreate(
+          [
+            'attendee_id' => $attendeeId,
+            'event_id' => $eventId,
+          ],
+          [
+            'status' => $status,
+            'check_in_time' => ($status === 'Present' && !Attendance::where('attendee_id', $attendeeId)->where('event_id', $eventId)->whereNotNull('check_in_time')->exists())
+              ? now()
+              : DB::raw('check_in_time'), // Preserve existing check_in_time
+          ]
+        );
+
+        // Log the update
+        UserLog::create([
+          'user_id' => $userId,
+          'action' => "Updated attendee ID {$attendeeId} status to {$status} for event ID {$eventId}",
+          'ip_address' => request()->ip(),
+          'device_info' => request()->userAgent(),
+          'status' => 'success',
+        ]);
+
+        $updatedCount++;
+      }
+
+      // Commit transaction
+      DB::commit();
+
+      return response()->json([
+        'success' => true,
+        'message' => 'Attendees status updated successfully',
+        'data' => [
+          'total_updated' => $updatedCount,
+          'total_not_found' => $notFoundCount,
+        ],
+      ], 200);
+    } catch (\Exception $e) {
+      // Rollback transaction if error occurs
+      DB::rollBack();
+
+      // Log error
+      UserLog::create([
+        'user_id' => $userId,
+        'action' => "Failed to update attendees for event ID {$eventId}: {$e->getMessage()}",
+        'ip_address' => request()->ip(),
+        'device_info' => request()->userAgent(),
+        'status' => 'failed',
+      ]);
+
+      return response()->json([
+        'success' => false,
+        'message' => 'Failed to update attendees: ' . $e->getMessage(),
+      ], 500);
+    }
   }
 }

--- a/app/Services/AttendanceService.php
+++ b/app/Services/AttendanceService.php
@@ -391,7 +391,7 @@ class AttendanceService
 
       foreach ($attendeesData as $attendeeData) {
         $attendeeId = $attendeeData['id'];
-        // Laravel best practice: konsistensi kapitalisasi status
+        // Laravel best practice: consistent status capitalization
         $status = strtolower($attendeeData['status']) === 'present' ? 'Present' : 'Absent';
 
         // Check if attendee belongs to this event

--- a/database/migrations/2025_07_01_043052_create_attendances_table.php
+++ b/database/migrations/2025_07_01_043052_create_attendances_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->foreignId('event_id')->constrained('events')->cascadeOnDelete();
             // qrcodes relation in qrcode schema migration
             $table->enum('status', [
-                'present', 'absent', 'late'
+                'Present', 'Absent', 'Late', 
             ]);
             $table->dateTime('check_in_time')->nullable();
             $table->text('notes')->nullable();

--- a/database/migrations/2025_07_01_045755_create_qr_code_logs_table.php
+++ b/database/migrations/2025_07_01_045755_create_qr_code_logs_table.php
@@ -13,9 +13,9 @@ return new class extends Migration
     {
         Schema::create('qr_code_logs', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('qr_code_id')->constrained('qr_codes')->cascadeOnDelete()->nullable();
-            $table->foreignId('attendee_id')->constrained('attendees')->cascadeOnDelete()->nullable();
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete()->nullable();
+            $table->foreignId('qr_code_id')->nullable()->constrained('qr_codes')->cascadeOnDelete();
+            $table->foreignId('attendee_id')->nullable()->constrained('attendees')->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained('users')->cascadeOnDelete();
             $table->enum('status', [
                 'Not Scanned',
                 'Scanned',

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,8 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::prefix('event')->group(function () {
         Route::post('{id}/scan-attendance', [ApiScanEventController::class, 'scanAttendance']);
         Route::post('{id}/scan-identity', [ApiScanEventController::class, 'scanIdentityCheck']);
+        Route::post('{id}/update-attendees', [ApiEventController::class, 'updateAttendees']);
+        Route::get('{id}/attendees', [ApiEventController::class, 'getEventAttendees']);
         Route::get('{id}', [ApiEventController::class, 'getEventById']);
     });
 


### PR DESCRIPTION
This pull request introduces several new controllers and major improvements to the event and dashboard management features, as well as a complete implementation of authentication and password reset flows. The changes focus on adding core functionality for attendee management, authentication (including password reset via email or WhatsApp), and richer dashboard and event data handling for different user roles.

**New Controllers and Authentication Flows:**

* Added `AuthController` with full login, logout, and multi-method password reset (email/WhatsApp OTP), including OTP verification and password change logic.
* Added `AttendeeController` for listing, editing, viewing, and deleting event attendees, with proper authorization checks and data loading.

**Dashboard and Event Management Enhancements:**

* Refactored `DashboardController` to load and filter events based on user role, categorize events by time (upcoming, ongoing, past), and provide admin statistics for super admins.
* Improved `EventController` to automatically update event and registration link statuses based on time, filter events by user role, and include related data in the event listing.

**Controller Base and Dependency Updates:**

* Updated the base `Controller` class to extend Laravel's base controller and use built-in authorization and validation traits, ensuring consistency and leveraging framework features.
* Enhanced imports in `DashboardController` to support new event and user logic.

These changes collectively provide a more robust backend for event and user management, improve security and usability for authentication, and set up the foundation for further admin and attendee features.

**References:**  
[[1]](diffhunk://#diff-138f5876b90f410274432eb9857380a1c69436e2ef1ae6b91702edf334f4ea4aR1-R186) [[2]](diffhunk://#diff-c29d4ec5e2aeab6b2ee33d385de631a0793ae7891206eb2c14a4c399c7cc9d5eR1-R68) [[3]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL14-R62) [[4]](diffhunk://#diff-e9e47c7018c1905fd246eae03c806f9201694932ce9a583c41431dc8896bcbdcR8-R60) [[5]](diffhunk://#diff-6eba513804f3952156d999eea3fb21199659f395d0092da71a10868b72bf59ceL5-R11) [[6]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL5-R8)